### PR TITLE
refactor(dashboard): added ability to filter offline channels

### DIFF
--- a/internal/lnd/data.go
+++ b/internal/lnd/data.go
@@ -2,17 +2,18 @@ package lnd
 
 import "github.com/charmbracelet/bubbles/list"
 
-
 type NodeData struct {
 	NodeInfo Node
 	Channels []Channel
 	Payments []Payment
 }
 
-func (n NodeData) GetChannelsAsListItems() []list.Item {
+func (n NodeData) GetChannelsAsListItems(onlyOffline bool) []list.Item {
 	var channelItems []list.Item
 	for _, channel := range n.Channels {
-		channelItems = append(channelItems, channel)
+		if (onlyOffline && !channel.Info.Active) || !onlyOffline {
+			channelItems = append(channelItems, channel)
+		}
 	}
 
 	return channelItems

--- a/internal/tui/constants.go
+++ b/internal/tui/constants.go
@@ -5,19 +5,20 @@ import (
 )
 
 type keyMap struct {
-	Close      key.Binding
-	ForceClose key.Binding
-	Update     key.Binding
-	Enter      key.Binding
-	Rename     key.Binding
-	Delete     key.Binding
-	Back       key.Binding
-	Quit       key.Binding
-	Left       key.Binding
-	Right      key.Binding
-	Tab        key.Binding
-	ReverseTab key.Binding
-	Help       key.Binding
+	Close           key.Binding
+	ForceClose      key.Binding
+	Update          key.Binding
+	Enter           key.Binding
+	Refresh         key.Binding
+	Delete          key.Binding
+	Back            key.Binding
+	Quit            key.Binding
+	Left            key.Binding
+	Right           key.Binding
+	Tab             key.Binding
+	ReverseTab      key.Binding
+	Help            key.Binding
+	OfflineChannels key.Binding
 }
 
 // Keymap reusable key mappings shared across models
@@ -33,6 +34,11 @@ var Keymap = keyMap{
 	ForceClose: key.NewBinding(
 		key.WithKeys("f"),
 		key.WithHelp("f", "force close"),
+	),
+
+	OfflineChannels: key.NewBinding(
+		key.WithKeys("o"),
+		key.WithHelp("o", "offline channels"),
 	),
 	Update: key.NewBinding(
 		key.WithKeys("u"),
@@ -50,9 +56,9 @@ var Keymap = keyMap{
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "select"),
 	),
-	Rename: key.NewBinding(
+	Refresh: key.NewBinding(
 		key.WithKeys("r"),
-		key.WithHelp("r", "rename"),
+		key.WithHelp("r", "refresh"),
 	),
 	Delete: key.NewBinding(
 		key.WithKeys("d"),


### PR DESCRIPTION
It's useful to show only channels that are offline. Enabled with "o". Use "r" to refresh the full list of channels.

fixes #26